### PR TITLE
Fix Typo for Script README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ Sourcelog
 
 ```bash
 # print help
-go run cmd/collector/main.go -help
+go run cmd/collect/main.go -help
 
 # Connect to ws://localhost:8546 and write CSVs into ./out
-go run cmd/collector/main.go -out ./out
+go run cmd/collect/main.go -out ./out
 
 # Connect to multiple nodes
-go run cmd/collector/main.go -out ./out -nodes ws://server1.com:8546,ws://server2.com:8546
+go run cmd/collect/main.go -out ./out -nodes ws://server1.com:8546,ws://server2.com:8546
 ```
 
 ## Merger


### PR DESCRIPTION
Fix Typo for Script README.md

## 📝 Summary

<!--- A general summary of your changes -->
`cmd/collector` should be `cmd/collect`

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
/

## 📚 References
/
<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
