### PR TITLE
store raw tx as bytes, lowercase to/from

### DIFF
--- a/common/common_test.go
+++ b/common/common_test.go
@@ -23,7 +23,7 @@ func TestParseTx(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, ts, summary.Timestamp)
 	require.Equal(t, test1Hash, summary.Hash)
-	require.Equal(t, "0xd8Aa8F3be2fB0C790D3579dcF68a04701C1e33DB", summary.From)
+	require.Equal(t, "0xd8aa8f3be2fb0c790d3579dcf68a04701c1e33db", summary.From)
 }
 
 func TestParquet(t *testing.T) {

--- a/common/txsfile.go
+++ b/common/txsfile.go
@@ -106,8 +106,8 @@ func LoadTransactionCSVFiles(log *zap.SugaredLogger, files, knownTxsFiles []stri
 	return txs, nil
 }
 
-func parseTx(timestampMs int64, hash, rawTx string) (TxSummaryEntry, *types.Transaction, error) {
-	tx, err := RLPStringToTx(rawTx)
+func parseTx(timestampMs int64, hash, rawTxHex string) (TxSummaryEntry, *types.Transaction, error) {
+	tx, err := RLPStringToTx(rawTxHex)
 	if err != nil {
 		return TxSummaryEntry{}, nil, err
 	}
@@ -129,13 +129,18 @@ func parseTx(timestampMs int64, hash, rawTx string) (TxSummaryEntry, *types.Tran
 		data4Bytes = hexutil.Encode(tx.Data()[:4])
 	}
 
+	rawTxBytes, err := hexutil.Decode(rawTxHex)
+	if err != nil {
+		return TxSummaryEntry{}, nil, err
+	}
+
 	return TxSummaryEntry{
 		Timestamp: timestampMs,
 		Hash:      tx.Hash().Hex(),
 
 		ChainID:   tx.ChainId().String(),
-		From:      from.Hex(),
-		To:        to,
+		From:      strings.ToLower(from.Hex()),
+		To:        strings.ToLower(to),
 		Value:     tx.Value().String(),
 		Nonce:     fmt.Sprint(tx.Nonce()),
 		Gas:       fmt.Sprint(tx.Gas()),
@@ -146,7 +151,7 @@ func parseTx(timestampMs int64, hash, rawTx string) (TxSummaryEntry, *types.Tran
 		DataSize:   int64(len(tx.Data())),
 		Data4Bytes: data4Bytes,
 
-		RawTx: rawTx,
+		RawTx: string(rawTxBytes),
 	}, tx, nil
 }
 

--- a/common/types.go
+++ b/common/types.go
@@ -22,7 +22,7 @@ type TxSummaryEntry struct {
 	DataSize   int64  `parquet:"name=dataSize, type=INT64"`
 	Data4Bytes string `parquet:"name=data4Bytes, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
 
-	RawTx string `parquet:"name=rawTx, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN, omitstats=true"`
+	RawTx string `parquet:"name=rawTx, type=BYTE_ARRAY, encoding=PLAIN, omitstats=true"`
 }
 
 func (t TxSummaryEntry) ToCSVRow() []string {


### PR DESCRIPTION
## 📝 Summary

Store raw txs as bytes instead of hex and uses lowecase addresses instead of mixed case addresses. 

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
