### PR TITLE
Chainbound error handling, also collect sourcelog by default, rename `blx` to `bloxroute`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,10 @@
+# API Keys
 export BLX_AUTH_HEADER=""
-export CLOUDFLARE_R2_ACCOUNT_ID=""
+export EDEN_AUTH_HEADER=""
+export CHAINBOUND_API_KEY=""
+
+# Source aliases
 export SRC_ALIASES="local=ws://localhost:8546" # comma-separated list of alias=url
+
+# Cloudflare R2 account ID (for upload.sh)
+export CLOUDFLARE_R2_ACCOUNT_ID=""

--- a/cmd/collect/main.go
+++ b/cmd/collect/main.go
@@ -33,7 +33,7 @@ var (
 	nodesPtr      = flag.String("nodes", "ws://localhost:8546", "comma separated list of EL nodes")
 	outDirPtr     = flag.String("out", "", "path to collect raw transactions into")
 	uidPtr        = flag.String("uid", "", "collector uid (part of output CSV filename)")
-	sourcelog     = flag.Bool("sourcelog", false, "write a CSV with all received transactions from any source (timestamp_ms,hash,source)")
+	sourcelog     = flag.Bool("sourcelog", true, "write a CSV with all received transactions from any source (timestamp_ms,hash,source)")
 
 	blxAuthToken     = flag.String("blx-token", defaultblxAuthToken, "bloxroute auth token (optional)")
 	chainboundAPIKey = flag.String("chainbound-api-key", defaultChainboundAPIKey, "chainbound API key (optional)")

--- a/collector/consts.go
+++ b/collector/consts.go
@@ -13,6 +13,7 @@ const (
 	// bucketMinutes is the number of minutes to write into each CSV file (i.e. new file created for every X minutes bucket)
 	bucketMinutes = 60
 
+	// exponential backoff settings
 	initialBackoffSec = 5
 	maxBackoffSec     = 120
 )
@@ -23,6 +24,8 @@ var (
 	// wss://uk.eth.blxrbdn.com/ws
 	// wss://singapore.eth.blxrbdn.com/ws
 	// wss://germany.eth.blxrbdn.com/ws
-	blxDefaultURL        = common.GetEnv("BLX_URI", "wss://virginia.eth.blxrbdn.com/ws")
+	blxDefaultURL = common.GetEnv("BLX_URI", "wss://virginia.eth.blxrbdn.com/ws")
+
+	// Chainbound Fiber URL
 	chainboundDefaultURL = common.GetEnv("CHAINBOUND_URI", "beta.fiberapi.io:8080")
 )

--- a/collector/node_conn_bloxroute.go
+++ b/collector/node_conn_bloxroute.go
@@ -65,9 +65,11 @@ func (nc *BlxNodeConnection) Start() {
 }
 
 func (nc *BlxNodeConnection) reconnect() {
-	time.Sleep(time.Duration(nc.backoffSec) * time.Second)
+	backoffDuration := time.Duration(nc.backoffSec) * time.Second
+	nc.log.Infof("reconnecting to %s in %s sec ...", nc.srcTag, backoffDuration.String())
+	time.Sleep(backoffDuration)
 
-	// increase backoff timeout
+	// increase backoff timeout for next try
 	nc.backoffSec *= 2
 	if nc.backoffSec > maxBackoffSec {
 		nc.backoffSec = maxBackoffSec

--- a/collector/node_conn_chainbound.go
+++ b/collector/node_conn_chainbound.go
@@ -52,24 +52,30 @@ func NewChainboundNodeConnection(opts ChainboundNodeOpts, txC chan TxIn) *Chainb
 }
 
 func (cbc *ChainboundNodeConnection) Start() {
+	cbc.log.Info("chainbound stream starting...")
+	cbc.fiberC = make(chan *fiber.Transaction)
 	go cbc.connect()
 
 	for fiberTx := range cbc.fiberC {
 		nativeTx := fiberTx.ToNative()
 		cbc.txC <- TxIn{time.Now().UTC(), nativeTx, cbc.srcTag}
 	}
+
+	cbc.log.Error("chainbound stream closed")
 }
 
 func (cbc *ChainboundNodeConnection) reconnect() {
-	time.Sleep(time.Duration(cbc.backoffSec) * time.Second)
+	backoffDuration := time.Duration(cbc.backoffSec) * time.Second
+	cbc.log.Infof("reconnecting to chainbound in %s sec ...", backoffDuration.String())
+	time.Sleep(backoffDuration)
 
-	// increase backoff timeout
+	// increase backoff timeout for next try
 	cbc.backoffSec *= 2
 	if cbc.backoffSec > maxBackoffSec {
 		cbc.backoffSec = maxBackoffSec
 	}
 
-	cbc.connect()
+	cbc.Start()
 }
 
 func (cbc *ChainboundNodeConnection) connect() {
@@ -88,12 +94,13 @@ func (cbc *ChainboundNodeConnection) connect() {
 	}
 
 	cbc.log.Infow("connection successful", "uri", cbc.url)
-	cbc.backoffSec = initialBackoffSec // reset backoff timeout
+	cbc.backoffSec = initialBackoffSec
 
 	// First make a sink channel on which to receive the transactions
 	// This is a blocking call, so it needs to run in a Goroutine
-	if err := client.SubscribeNewTxs(nil, cbc.fiberC); err != nil {
-		cbc.log.Errorw("failed to connect to chainbound", "error", err)
+	err := client.SubscribeNewTxs(nil, cbc.fiberC)
+	if err != nil {
+		cbc.log.Errorw("chainbound subscription error", "error", err)
 		go cbc.reconnect()
 		return
 	}

--- a/common/consts.go
+++ b/common/consts.go
@@ -3,7 +3,7 @@ package common
 import "strings"
 
 const (
-	BloxrouteTag  = "blx"
+	BloxrouteTag  = "bloxroute"
 	ChainboundTag = "chainbound"
 )
 


### PR DESCRIPTION
## 📝 Summary

- Improved chainbound error handling
- Collect sourcelog by default
- rename `blx` to `bloxroute`

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
