### PR TITLE
Fix Undefined outFilesSrcStats when doing cleanupBackgroundTask in Collector

### DIFF
--- a/collector/tx_processor.go
+++ b/collector/tx_processor.go
@@ -203,10 +203,12 @@ func (p *TxProcessor) getOutputCSVFiles(timestamp int64) (fTx, fSrcStats *os.Fil
 	}
 
 	// if one file was opened, record it now
-	if !fTxOk || (p.recSourcelog && !fSrcStatsOk) {
+	if !fTxOk {
 		p.outFilesLock.Lock()
 		p.outFiles[bucketTS] = fTx
-		p.outFilesSrcStats[bucketTS] = fSrcStats
+		if p.recSourcelog && !fSrcStatsOk {
+			p.outFilesSrcStats[bucketTS] = fSrcStats
+		}
 		p.outFilesLock.Unlock()
 		isCreated = true
 	}


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->
Fix Undefined outFilesSrcStats when doing cleanupBackgroundTask in Collector

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Currently `recSourcelog` is set to false by default. Running collector will access
```
go run cmd/collect/main.go -out ./out -nodes ws://127.0.0.1:23456

2023-09-09T19:20:33.921Z        INFO    source_stats_all        {"ws://127.0.0.1:23456": "474"}
2023-09-09T19:20:33.921Z        INFO    source_stats_unique     {"ws://127.0.0.1:23456": "0"}
2023-09-09T19:21:00.112Z        INFO    new file created: out/2023-09-09/transactions/txs_2023-09-09_19-21_rSQzKJ.csv
2023-09-09T19:21:33.922Z        INFO    closing file    {"timestamp": 1694287140, "filename": "out/2023-09-09/transactions/txs_2023-09-09_19-19_rSQzKJ.csv"}
map[1694287140:<nil> 1694287200:<nil> 1694287260:<nil>]
File is nil
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x964f60]

goroutine 18 [running]:
os.(*File).Name(...)
        /usr/local/go/src/os/file.go:56
github.com/flashbots/mempool-dumpster/collector.(*TxProcessor).cleanupBackgroundTask(0xc00025cea0)
        /home/ubuntu/tools/mempool-dumpster/collector/tx_processor.go:258 +0xf60
created by github.com/flashbots/mempool-dumpster/collector.(*TxProcessor).Start in goroutine 6
        /home/ubuntu/tools/mempool-dumpster/collector/tx_processor.go:71 +0xde
exit status 2
```

this is because the assigned file descriptor to outFilesSrcStats is nil `p.outFilesSrcStats[bucketTS] = fSrcStats`. (https://github.com/0xJchen/mempool-dumpster/blob/04278aa083923552d4da33ad973edd0c48f9d376/collector/tx_processor.go#L210C7-L210C7)

This can be fixed by separate the checking of `outFiles` and `outFilesSrcStats`.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
