### PR TITLE
Add merkle connector

### DIFF
--- a/collector/node_conn_merkle.go
+++ b/collector/node_conn_merkle.go
@@ -1,0 +1,73 @@
+package collector
+
+// Plug into Chainbound fiber as mempool data source (via websocket stream):
+// https://fiber.chainbound.io/docs/usage/getting-started/
+
+import (
+	"time"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/flashbots/mempool-dumpster/common"
+	"github.com/merkle3/merkle-sdk-go/merkle"
+	"go.uber.org/zap"
+)
+
+type MerkleNodeOpts struct {
+	TxC       chan TxIn
+	Log       *zap.SugaredLogger
+	APIKey    string
+	SourceTag string // optional override, default: "merkle"
+}
+
+type MerkleNodeConection struct {
+	log    *zap.SugaredLogger
+	sdk    *merkle.MerkleSDK
+	srcTag string
+	txC    chan TxIn
+}
+
+func NewMerkleNodeConnection(opts MerkleNodeOpts) *MerkleNodeConection {
+	srcTag := opts.SourceTag
+	if srcTag == "" {
+		srcTag = common.SourceTagMerkle
+	}
+
+	sdk := merkle.New()
+
+	sdk.SetApiKey(opts.APIKey)
+
+	return &MerkleNodeConection{
+		log:    opts.Log.With("src", srcTag),
+		sdk:    sdk,
+		srcTag: srcTag,
+		txC:    opts.TxC,
+	}
+}
+
+func (cbc *MerkleNodeConection) Start() {
+	cbc.log.Debug("merkle stream starting...")
+	go cbc.connect()
+	cbc.log.Error("merkle stream closed")
+}
+
+func (cbc *MerkleNodeConection) connect() {
+	cbc.log.Infow("connecting...")
+
+	txs, err := cbc.sdk.Transactions().Stream(merkle.EthereumMainnet) // pass a chain id
+
+	for {
+		select {
+		case e := <-err:
+			cbc.log.Errorw("merkle subscription error", "error", e)
+		case _tx := <-txs:
+			// process the transaction
+			go func(tx *types.Transaction) {
+				cbc.txC <- TxIn{
+					T:      time.Now().UTC(),
+					Tx:     tx,
+					Source: cbc.srcTag,
+				}
+			}(_tx)
+		}
+	}
+}

--- a/collector/node_conn_merkle.go
+++ b/collector/node_conn_merkle.go
@@ -1,7 +1,7 @@
 package collector
 
-// Plug into Chainbound fiber as mempool data source (via websocket stream):
-// https://fiber.chainbound.io/docs/usage/getting-started/
+// Plug into merkle as mempool data source (via websocket stream):
+// https://docs.merkle.io/transaction-network/what-is-transaction-network
 
 import (
 	"time"

--- a/common/consts.go
+++ b/common/consts.go
@@ -6,6 +6,7 @@ const (
 	SourceTagLocal      = "local"
 	SourceTagBloxroute  = "bloxroute"
 	SourceTagChainbound = "chainbound"
+	SourceTagMerkle     = "merkle"
 	SourceTagEden       = "eden"
 	SourceTagAlchemy    = "alchemy"
 	SourceTagInfura     = "infura"

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/klauspost/compress v1.16.7 // indirect
 	github.com/mattn/go-isatty v0.0.18 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
+	github.com/merkle3/merkle-sdk-go v0.13.0 // indirect
 	github.com/onsi/gomega v1.27.4 // indirect
 	github.com/pierrec/lz4/v4 v4.1.8 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -520,6 +520,8 @@ github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWV
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/merkle3/merkle-sdk-go v0.13.0 h1:XflyAH0jNlnjgo6zY6G/nVK3v8BE3PwZkvJ4+2J1UVo=
+github.com/merkle3/merkle-sdk-go v0.13.0/go.mod h1:5uDa7v0wsfZ9B5Nx5ol2bCLuQjWlzMThDYpfrbvxCwE=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
 github.com/minio/minio-go/v7 v7.0.34/go.mod h1:nCrRzjoSUQh8hgKKtu3Y708OLvRLtuASMg2/nvmbarw=
 github.com/minio/sha256-simd v1.0.0/go.mod h1:OuYzVNI5vcoYIAmbIvHPl3N3jUzVedXbKy5RFepssQM=

--- a/scripts/subscibe-test/main.go
+++ b/scripts/subscibe-test/main.go
@@ -23,7 +23,8 @@ func pcheck(err error) {
 }
 
 func main() {
-	MainEden()
+	MainMerkle()
+	// MainEden()
 	// MainBlx()
 	// MainChainbound()
 }
@@ -49,6 +50,23 @@ func MainBlx() {
 		URL:        url,
 	}
 	nc := collector.NewBlxNodeConnectionGRPC(blxOpts)
+	go nc.Start()
+	for tx := range txC {
+		log.Infow("received tx", "tx", tx.Tx.Hash(), "src", tx.Source)
+	}
+}
+
+func MainMerkle() {
+	txC := make(chan collector.TxIn)
+	log := common.GetLogger(true, false)
+	apiKey := os.Getenv("MKL_AUTH")
+
+	mklOpts := collector.MerkleNodeOpts{
+		TxC:    txC,
+		Log:    log,
+		APIKey: apiKey,
+	}
+	nc := collector.NewMerkleNodeConnection(mklOpts)
 	go nc.Start()
 	for tx := range txC {
 		log.Infow("received tx", "tx", tx.Tx.Hash(), "src", tx.Source)
@@ -83,7 +101,7 @@ func MainChainbound() {
 	nc := collector.NewChainboundNodeConnection(opts)
 	go nc.Start()
 	for tx := range txC {
-		log.Infow("received tx", "tx", tx.Tx.Hash(), "src", tx.Source)
+		log.Infow("received tx", "tx", tx.Tx.Hash(), "`src", tx.Source)
 	}
 }
 

--- a/scripts/subscibe-test/main.go
+++ b/scripts/subscibe-test/main.go
@@ -101,7 +101,7 @@ func MainChainbound() {
 	nc := collector.NewChainboundNodeConnection(opts)
 	go nc.Start()
 	for tx := range txC {
-		log.Infow("received tx", "tx", tx.Tx.Hash(), "`src", tx.Source)
+		log.Infow("received tx", "tx", tx.Tx.Hash(), "src", tx.Source)
 	}
 }
 


### PR DESCRIPTION
## 📝 Summary

Adds a connector to the merkle transaction stream, a competitive streaming service for pending transactions on Ethereum.

## ⛱ Motivation and Context

Compare this stream with other streaming services.

## 📚 References

https://merkle.io

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test`
* [ ] `go mod tidy`
