### PR TITLE
fix make lint by updating staticcheck

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -40,7 +40,7 @@ jobs:
         run: go install mvdan.cc/gofumpt@v0.6.0
 
       - name: Install staticcheck
-        run: go install honnef.co/go/tools/cmd/staticcheck@v0.4.7
+        run: go install honnef.co/go/tools/cmd/staticcheck@v0.5.1
 
       - name: Install golangci-lint
         run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2

--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -15,7 +15,7 @@ import (
 var (
 	version = "dev" // is set during build process
 	debug   = os.Getenv("DEBUG") == "1"
-	max     = common.GetEnvInt("MAX", 0)
+	maxEnv  = common.GetEnvInt("MAX", 0)
 
 	// Helpers
 	log *zap.SugaredLogger
@@ -119,7 +119,7 @@ func analyzeV2(cCtx *cli.Context) error {
 			log.Infow(common.Printer.Sprintf("- Loaded %10d / %d rows", i, num), "memUsed", common.GetMemUsageHuman())
 		}
 		entries[stus[0].Hash] = &stus[0]
-		if i+1 == max {
+		if i+1 == maxEnv {
 			break
 		}
 	}

--- a/common/analyzer.go
+++ b/common/analyzer.go
@@ -246,7 +246,7 @@ func (a *Analyzer2) Sprint() string {
 	out += Printer.Sprintf("- Included on-chain: %10d (%5s) \n", a.nIncluded, Int64DiffPercentFmt(a.nIncluded, a.nUniqueTransactions, 1))
 	out += Printer.Sprintf("- Not included:      %10d (%5s) \n", a.nNotIncluded, Int64DiffPercentFmt(a.nNotIncluded, a.nUniqueTransactions, 1))
 
-	if a.Sourelog == nil || len(a.Sourelog) == 0 {
+	if len(a.Sourelog) == 0 {
 		return out
 	}
 


### PR DESCRIPTION
fixes `panic: Cannot range over: func(yield func(K, V) bool)` seen in the older version of staticcheck