### PR TITLE
fix(fiber): don't panic

### DIFF
--- a/collector/node_conn_chainbound.go
+++ b/collector/node_conn_chainbound.go
@@ -86,7 +86,6 @@ func (cbc *ChainboundNodeConnection) connect() {
 	cbc.log.Infow("connecting...", "uri", cbc.url)
 
 	client := fiber.NewClient(chainboundDefaultURL, cbc.apiKey)
-	defer client.Close()
 
 	// Connect
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -96,6 +95,9 @@ func (cbc *ChainboundNodeConnection) connect() {
 		go cbc.reconnect()
 		return
 	}
+
+	// Only close the client when the connection was successful
+	defer client.Close()
 
 	cbc.log.Infow("connection successful", "uri", cbc.url)
 	cbc.backoffSec = initialBackoffSec


### PR DESCRIPTION
## 📝 Summary

Fixes a bug where the Fiber client panics if closed without a successful connection first

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
