### PR TITLE
chore: bump fiber-go to v1.9.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/bloXroute-Labs/gateway/v2 v2.127.42
-	github.com/chainbound/fiber-go v1.9.3
+	github.com/chainbound/fiber-go v1.9.4
 	github.com/dustin/go-humanize v1.0.1
 	github.com/eden-network/mempool-service v1.0.1
 	github.com/ethereum/go-ethereum v1.14.13

--- a/go.sum
+++ b/go.sum
@@ -176,6 +176,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chainbound/fiber-go v1.9.3 h1:91FrSozDALjS/dLjEiRI9+v3C707oRy9rqYurzqugtg=
 github.com/chainbound/fiber-go v1.9.3/go.mod h1:7U5FZ/KbIXAGEMToTJaEFrWl2Zf/aDT0IGRSACPWhIE=
+github.com/chainbound/fiber-go v1.9.4 h1:yNH4wPxS5m6m3HgFVkZe2wEkwz8fNoyrji9zF7IYagA=
+github.com/chainbound/fiber-go v1.9.4/go.mod h1:7U5FZ/KbIXAGEMToTJaEFrWl2Zf/aDT0IGRSACPWhIE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=


### PR DESCRIPTION
## 📝 Summary

Update fiber-go to v1.9.4

## ⛱ Motivation and Context

This new release fixes race conditions in concurrent connections, prevents stream termination issues, and improves connection cleanup. Instead of ignoring some internal errors they are now logged.

## 📚 References

https://github.com/chainbound/fiber-go/releases/tag/v1.9.4

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
