### PR TITLE
chore: increase fiber connection timeout

### DIFF
--- a/collector/node_conn_chainbound.go
+++ b/collector/node_conn_chainbound.go
@@ -90,7 +90,7 @@ func (cbc *ChainboundNodeConnection) connect() {
 	client := fiber.NewClientWithConfig(chainboundDefaultURL, cbc.apiKey, config)
 
 	// Connect
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	if err := client.Connect(ctx); err != nil {
 		cbc.log.Errorw("failed to connect to chainbound, reconnecting in a bit...", "error", err)


### PR DESCRIPTION
## 📝 Summary

Increase Fiber connection timeout

## ⛱ Motivation and Context

3 seconds is not a lot of time to connect and if there are issue you might end up stuck in a backoff loop since `fiber-go` internally uses exponential backoff for connecting. Increase the timeout to give more opportunity for connecting.


## 📚 References

https://github.com/chainbound/fiber-go/blob/7b824ca1a554501951cf70cae0350fcb5967706c/client.go#L122-L133


---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
