### PR TITLE
fix: make chainbound reconnecting more robust

### DIFF
--- a/collector/node_conn_chainbound.go
+++ b/collector/node_conn_chainbound.go
@@ -57,7 +57,7 @@ func (cbc *ChainboundNodeConnection) Start() {
 		// (Re)create incoming-tx channel
 		ch := make(chan *fiber.TransactionWithSender)
 
-		// Fire off connect (will close fiberC on error)
+		// Fire off connect (will close ch on error)
 		go cbc.connect(ch)
 
 		// Forward transactions to collector

--- a/collector/node_conn_chainbound.go
+++ b/collector/node_conn_chainbound.go
@@ -92,7 +92,7 @@ func (cbc *ChainboundNodeConnection) connect() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	if err := client.Connect(ctx); err != nil {
-		cbc.log.Errorw("failed to connect to chainbound, reconnecting in a bit...", "error", err)
+		cbc.log.Errorw("failed to connect to chainbound", "error", err)
 		close(cbc.fiberC)
 		return
 	}


### PR DESCRIPTION
## 📝 Summary

Simplify Chainbound reconnection logic.
<!--- A general summary of your changes -->

## ⛱ Motivation and Context

Before it had recursive start -> reconnect -> start, which was hard to reason about and could lead to unbounded call-stack growth. Now there's a single outer loop in `Start()`.

Instead of modifying the `ChainboundNodeConnection` across channels, which is brittle, we now pass the channel as a function param to avoid possible race condition.


---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
