### PR TITLE
Prometheus Metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ build: clean-build  ## build the binaries
 
 .PHONY: website
 website: ## Build the website and upload to R2
-	go run cmd/website/main.go -build -upload
+	go run cmd/main.go website build --upload
 
 .PHONY: docker-image
 docker-image: ## Build the docker image
@@ -36,7 +36,7 @@ clean-dev: ## Clean dev files
 	rm -rf out/ test/
 
 website-dev: ## Run the website in dev mode (hot reloading templates)
-	go run cmd/website/main.go -dev
+	go run cmd/main.go website dev
 
 test: ## Run tests
 	go test ./...

--- a/cmd/collect/main.go
+++ b/cmd/collect/main.go
@@ -39,6 +39,16 @@ var cliFlags = []cli.Flag{
 		Category: "Collector Configuration",
 	},
 
+	// Metrics
+	&cli.StringFlag{
+		Name:     "metrics-listen-addr",
+		EnvVars:  []string{"METRICS_ADDR"},
+		Value:    "localhost:9090",
+		Required: false,
+		Usage:    "Metrics listen address (host:port)",
+		Category: "Collector Configuration",
+	},
+
 	// Sources
 	&cli.StringSliceFlag{
 		Name:     "node",
@@ -109,6 +119,7 @@ func runCollector(cCtx *cli.Context) error {
 		receivers               = cCtx.StringSlice("tx-receivers")
 		receiversAllowedSources = cCtx.StringSlice("tx-receivers-allowed-sources")
 		apiListenAddr           = cCtx.String("api-listen-addr")
+		metricsListenAddr       = cCtx.String("metrics-listen-addr")
 	)
 
 	// Logger setup
@@ -143,6 +154,7 @@ func runCollector(cCtx *cli.Context) error {
 		Receivers:               receivers,
 		ReceiversAllowedSources: receiversAllowedSources,
 		APIListenAddr:           apiListenAddr,
+		MetricsListenAddr:       metricsListenAddr,
 	}
 
 	collector.Start(&opts)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.24.2
 require (
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2
 	github.com/NYTimes/gziphandler v1.1.1
+	github.com/VictoriaMetrics/metrics v1.37.0
 	github.com/bloXroute-Labs/gateway/v2 v2.127.42
 	github.com/chainbound/fiber-go v1.10.0
 	github.com/dustin/go-humanize v1.0.1
@@ -87,6 +88,8 @@ require (
 	github.com/tdewolff/test v1.0.9 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
+	github.com/valyala/fastrand v1.1.0 // indirect
+	github.com/valyala/histogram v1.2.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMo
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=
 github.com/VictoriaMetrics/fastcache v1.12.2/go.mod h1:AmC+Nzz1+3G2eCPapF6UcsnkThDcMsQicp4xDukwJYI=
+github.com/VictoriaMetrics/metrics v1.37.0 h1:u5Yr+HFofQyn7kgmmkufgkX0nEA6G1oEyK2eaKsVaUM=
+github.com/VictoriaMetrics/metrics v1.37.0/go.mod h1:r7hveu6xMdUACXvB8TYdAj8WEsKzWB0EkpJN+RDtOf8=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/allegro/bigcache v1.2.1 h1:hg1sY1raCwic3Vnsvje6TT7/pnZba83LeFck5NrFKSc=
@@ -692,6 +694,10 @@ github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVM
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/urfave/cli/v2 v2.27.5 h1:WoHEJLdsXr6dDWoJgMq/CboDmyY/8HMMH1fTECbih+w=
 github.com/urfave/cli/v2 v2.27.5/go.mod h1:3Sevf16NykTbInEnD0yKkjDAeZDS0A6bzhBH5hrMvTQ=
+github.com/valyala/fastrand v1.1.0 h1:f+5HkLW4rsgzdNoleUOB69hyT9IlD2ZQh9GyDMfb5G8=
+github.com/valyala/fastrand v1.1.0/go.mod h1:HWqCzkrkg6QXT8V2EXWvXCoow7vLwOFN002oeRzjapQ=
+github.com/valyala/histogram v1.2.0 h1:wyYGAZZt3CpwUiIb9AU/Zbllg1llXyrtApRS815OLoQ=
+github.com/valyala/histogram v1.2.0/go.mod h1:Hb4kBwb4UxsaNbbbh+RRz8ZR6pdodR57tzWUS3BUzXY=
 github.com/xitongsys/parquet-go v1.5.1/go.mod h1:xUxwM8ELydxh4edHGegYq1pA8NnMKDx0K/GyB0o2bww=
 github.com/xitongsys/parquet-go v1.6.2 h1:MhCaXii4eqceKPu9BwrjLqyK10oX9WF+xGhwvwbw7xM=
 github.com/xitongsys/parquet-go v1.6.2/go.mod h1:IulAQyalCm0rPiZVNnCgm/PCL64X2tdSVGMQ/UeKqWA=

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,37 @@
+package metrics
+
+import (
+	"fmt"
+
+	"github.com/VictoriaMetrics/metrics"
+)
+
+var (
+	txReceived      = metrics.NewCounter("tx_received_total")
+	txReceivedFirst = metrics.NewCounter("tx_received_first")
+	txReceivedTrash = metrics.NewCounter("tx_received_trash")
+)
+
+const (
+	TxReceivedSourceLabel      = `tx_received_total{source="%s"}`
+	TxReceivedFirstSourceLabel = `tx_received_first{source="%s"}`
+	TxReceivedTrashLabel       = `tx_received_trash{source="%s"}`
+)
+
+func IncTxReceived(source string) {
+	txReceived.Inc()
+	l := fmt.Sprintf(TxReceivedSourceLabel, source)
+	metrics.GetOrCreateCounter(l).Inc()
+}
+
+func IncTxReceivedFirst(source string) {
+	txReceivedFirst.Inc()
+	l := fmt.Sprintf(TxReceivedFirstSourceLabel, source)
+	metrics.GetOrCreateCounter(l).Inc()
+}
+
+func IncTxReceivedTrash(source string) {
+	txReceivedTrash.Inc()
+	l := fmt.Sprintf(TxReceivedTrashLabel, source)
+	metrics.GetOrCreateCounter(l).Inc()
+}

--- a/scripts/backfill-example.sh
+++ b/scripts/backfill-example.sh
@@ -34,7 +34,7 @@ while [ "$date" != $date_to ]; do
         sourcelog_arg="--sourcelog ${DATA_DIR}/${date}/orig/${date}_sourcelog.csv"
     fi
 
-    $SCRIPT_DIR/../../build/merge t \
+    $SCRIPT_DIR/../../build/mempool-dumpster merge t \
         --out "${DATA_DIR}/${date}/" \
         --fn-prefix $date \
         --write-tx-csv \

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -51,10 +51,10 @@ fi
 # PROCESS RAW FILES
 #
 echo "Merging sourcelog..."
-/server/mempool-dumpster/build/merge sourcelog --out $1 --fn-prefix $date $1/sourcelog/*.csv
+/server/mempool-dumpster/build/mempool-dumpster merge sourcelog --out $1 --fn-prefix $date $1/sourcelog/*.csv
 
 echo "Merging transactions..."
-/server/mempool-dumpster/build/merge transactions \
+/server/mempool-dumpster/build/mempool-dumpster merge transactions \
   --out $1 \
   --fn-prefix $date \
   --write-tx-csv \


### PR DESCRIPTION
## 📝 Summary

Added Prometheus Metrics:

https://github.com/flashbots/mempool-dumpster/blob/metrics/metrics/metrics.go#L9-L20

By default exposes metrics server on `localhost:9090`, configurable by:
- `--metrics-listen-addr`
- env var: `METRICS_ADDR`

```bash
curl -s localhost:9090/metrics | grep tx
```