### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/common/txsummary.go
+++ b/common/txsummary.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -68,12 +69,7 @@ type TxSummaryEntry struct {
 }
 
 func (t *TxSummaryEntry) HasSource(src string) bool {
-	for _, s := range t.Sources {
-		if s == src {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(t.Sources, src)
 }
 
 func (t *TxSummaryEntry) RawTxHex() string {


### PR DESCRIPTION
## 📝 Summary

There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.


## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test`
* [ ] `go mod tidy`
