### PR TITLE
Make output directory optional for collector

### DIFF
--- a/cmd/collect/main.go
+++ b/cmd/collect/main.go
@@ -22,8 +22,8 @@ var cliFlags = []cli.Flag{
 	&cli.StringFlag{
 		Name:     "out",
 		EnvVars:  []string{"OUT"},
-		Required: true,
-		Usage:    "output base directory",
+		Required: false,
+		Usage:    "output base directory (optional, file writes disabled if not set)",
 		Category: "Collector Configuration",
 	},
 	&cli.StringFlag{
@@ -163,6 +163,10 @@ func runCollector(cCtx *cli.Context) error {
 
 	if len(nodeURIs) == 0 && len(blxAuth) == 0 && len(edenAuth) == 0 && len(chainboundAuth) == 0 {
 		log.Fatal("No nodes, bloxroute, or eden token set (use -nodes <url1>,<url2> / -blx-token <token> / -eden-token <token>)")
+	}
+
+	if outDir == "" && clickhouseDSN == "" {
+		log.Fatal("Either --out or --clickhouse-dsn must be specified")
 	}
 
 	log.Infow("Starting mempool-collector", "version", common.Version, "outDir", outDir, "uid", uid, "enablePprof", enablePprof)


### PR DESCRIPTION
## 📝 Summary

- Make --out flag optional in CLI configuration
- Add validation requiring either --out or --clickhouse-dsn to be specified
- Modify TxProcessor to handle empty OutDir by skipping file operations
- Refactor error handling to separate validation from file writing
- Use slices.Contains for cleaner source validation
- Change use of map[int]*OutFiles to map[int]OutFiles to better handle no-write case 

The code and summary was heavily llm-generated and manually reviewed/fixed.

Better viewed with whitespace changes hidden.

## ⛱ Motivation and Context

We want to deploy collector in k8s and there we don't need to write any files, only write to CH

## 📚 References


---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
