### PR TITLE
Clickhouse: store raw_tx as bytes instead of hex

### DIFF
--- a/common/txsummary.go
+++ b/common/txsummary.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 )
@@ -78,6 +79,10 @@ func (t *TxSummaryEntry) HasSource(src string) bool {
 
 func (t *TxSummaryEntry) RawTxHex() string {
 	return fmt.Sprintf("0x%x", t.RawTx)
+}
+
+func (t *TxSummaryEntry) RawTxBytes() ([]byte, error) {
+	return hexutil.Decode(t.RawTxHex())
 }
 
 func (t *TxSummaryEntry) WasIncludedBeforeReceived() bool {


### PR DESCRIPTION
halves the amount of data stored

tested manually, with:

```bash

SELECT
    hash,
    hex(raw_tx)
FROM transactions
WHERE hash = '0x6aa923498856a4174113089b6d0f98ed381aac8c46a987c31f15116a8152db63'
FORMAT Vertical

Query id: b1587cdf-aeac-4140-9c16-a10d8e7f7b45

Row 1:
──────
hash:        0x6aa923498856a4174113089b6d0f98ed381aac8c46a987c31f15116a8152db63
hex(raw_tx): 02F90335018238008505D21DBA0085069B1C659E830F424094FD82767D97C84A17D5F2D88E6FF36C72241E85D980B902C4A9059CBB02000000000000000000000000000000000000000000000000000000000000008592F5822033D79BC7CD588822F49E0C25696E84626CB14BE46AC0518A5884C800000000000000000000000018F53AB8EE03C6F8B3F3421336D2E153B4F1B21C000000000000000000000000C02AAA39B223FE8D0A0E5C4F27EAD9083C756CC2000000000000000000000000BCA23CC4B274A0E7E6F64DBC7E739CF5AAA6A3E1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002600000000000000000000000000000000000000000000AC0DB698068112D00000000000000000000000000000000000000000000000000000030927F74C9DE0000000000000000000000000000000000000000000000084595161401484A000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000009184E72A000000000000000000000000000000000000000000000000000000000000000003200000000000000000000000000000000000000000000000000000000000000320000000000000000000000000000000000000000000000000A688906BD8B00000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002000000000000000000000000E95FC0C7D17091193C70F963B23D6576FE7E32DE000000000000000000000000EF7A6E55095218A0E5ED37C34E3E547EEAA5F09BC080A0F8E10D102B34D6130E32B6108E86CBEBEC8E1FF9CE6765EB7C670DBF7D1C87F1A0390751EE76C406D7E340A3A2CE28B5830D2BAA2B33EE1C6DFD4C200046634F59
```

Same result on Etherscan: https://etherscan.io/getRawTx?tx=0x6aa923498856a4174113089b6d0f98ed381aac8c46a987c31f15116a8152db63