### PR TITLE
Fix goreleaser error

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,9 +29,6 @@ builds:
 # https://goreleaser.com/customization/release/
 release:
   draft: true
-  extra_files:
-    - glob: ./dist/mempool-dumpster*.tar.gz
-    - glob: ./dist/mempool-dumpster*.txt
   header: |
     # 🚀 Features
     # 🎄 Enhancements


### PR DESCRIPTION
Previously CI errored on releases because of files already existing: https://github.com/flashbots/mempool-dumpster/actions/runs/16019675851/job/45193399640

Works now.