### PR TITLE
Minor cleanup of collector and processor 

### DIFF
--- a/api/handler.go
+++ b/api/handler.go
@@ -41,6 +41,7 @@ func (s *Server) handleTxSSE(w http.ResponseWriter, r *http.Request) {
 			return
 
 		case tx := <-subscriber.txC:
+			// Note/TODO: a client with a slow connection may cause blocking other clients and cause DoS on all receivers
 			fmt.Fprintf(w, "data: %s\n\n", tx)
 			w.(http.Flusher).Flush() //nolint:forcetypeassert
 

--- a/api/server.go
+++ b/api/server.go
@@ -102,7 +102,7 @@ func (s *Server) removeSubscriber(sub *SSESubscription) {
 	s.sseConnectionLock.Lock()
 	defer s.sseConnectionLock.Unlock()
 	delete(s.sseConnectionMap, sub.uid)
-	s.log.With("subscribers", len(s.sseConnectionMap)).Info("removed subscriber")
+	s.log.With("subscribers", len(s.sseConnectionMap)).Debug("removed subscriber")
 }
 
 func (s *Server) SendTx(ctx context.Context, tx *common.TxIn) error {

--- a/cmd/collect/main.go
+++ b/cmd/collect/main.go
@@ -172,22 +172,21 @@ func runCollector(cCtx *cli.Context) error {
 
 	// Start service components
 	collector := collector.New(collector.CollectorOpts{
-		Log:                      log,
-		UID:                      uid,
-		Location:                 location,
-		OutDir:                   outDir,
-		CheckNodeURI:             checkNodeURI,
-		ClickhouseDSN:            clickhouseDSN,
-		Nodes:                    nodeURIs,
-		BloxrouteAuth:            blxAuth,
-		EdenAuth:                 edenAuth,
-		ChainboundAuth:           chainboundAuth,
-		Receivers:                receivers,
-		ReceiversAllowedSources:  receiversAllowedSources,
-		ReceiversAllowAllSources: len(receiversAllowedSources) == 1 && receiversAllowedSources[0] == "all",
-		APIListenAddr:            apiListenAddr,
-		MetricsListenAddr:        metricsListenAddr,
-		EnablePprof:              enablePprof,
+		Log:                     log,
+		UID:                     uid,
+		Location:                location,
+		OutDir:                  outDir,
+		CheckNodeURI:            checkNodeURI,
+		ClickhouseDSN:           clickhouseDSN,
+		Nodes:                   nodeURIs,
+		BloxrouteAuth:           blxAuth,
+		EdenAuth:                edenAuth,
+		ChainboundAuth:          chainboundAuth,
+		Receivers:               receivers,
+		ReceiversAllowedSources: receiversAllowedSources,
+		APIListenAddr:           apiListenAddr,
+		MetricsListenAddr:       metricsListenAddr,
+		EnablePprof:             enablePprof,
 	})
 	collector.Start()
 

--- a/cmd/collect/main.go
+++ b/cmd/collect/main.go
@@ -195,6 +195,10 @@ func runCollector(cCtx *cli.Context) error {
 	signal.Notify(exit, os.Interrupt, syscall.SIGTERM)
 	<-exit
 
+	// Shutdown collector gracefully
+	log.Info("Received termination signal, shutting down collector...")
+	collector.Shutdown()
+
 	// All done, log goodbye message
 	log.Info("bye")
 	return nil

--- a/collector/clickhouse.go
+++ b/collector/clickhouse.go
@@ -235,21 +235,3 @@ func (ch *Clickhouse) sendBatchWithRetries(name string, batch driver.Batch) {
 		metrics.IncClickhouseBatchSaveRetries()
 	}
 }
-
-// FlishData flushes any remaining transactions and source logs in the batch to Clickhouse.
-// This is useful for ensuring all data is saved before shutting down the collector.
-// Needs a lock to avoid concurrent access to the batches.
-//
-// func (ch *Clickhouse) FlushData() {
-// 	// Flush any remaining transactions in the batch
-// 	if len(ch.currentTxBatch) > 0 {
-// 		ch.saveTxs(slices.Clone(ch.currentTxBatch))
-// 		ch.currentTxBatch = ch.currentTxBatch[:0] // Clear the slice without reallocating
-// 	}
-
-// 	// Flush any remaining source logs in the batch
-// 	if len(ch.currentSourcelogBatch) > 0 {
-// 		ch.saveSourcelogs(slices.Clone(ch.currentSourcelogBatch))
-// 		ch.currentSourcelogBatch = ch.currentSourcelogBatch[:0] // Clear the slice without reallocating
-// 	}
-// }

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -27,9 +27,8 @@ type CollectorOpts struct {
 	EdenAuth       []string
 	ChainboundAuth []string
 
-	Receivers                []string
-	ReceiversAllowedSources  []string
-	ReceiversAllowAllSources bool // if true, allows all sources for receivers
+	Receivers               []string
+	ReceiversAllowedSources []string
 
 	APIListenAddr     string
 	MetricsListenAddr string
@@ -57,16 +56,15 @@ func (c *Collector) Start() {
 
 	// Initialize the transaction processor, which is the brain of the collector
 	c.processor = NewTxProcessor(TxProcessorOpts{
-		Log:                      c.log,
-		UID:                      c.opts.UID,
-		Location:                 c.opts.Location,
-		OutDir:                   c.opts.OutDir,
-		CheckNodeURI:             c.opts.CheckNodeURI,
-		ClickhouseDSN:            c.opts.ClickhouseDSN,
-		HTTPReceivers:            c.opts.Receivers,
-		ReceiversAllowedSources:  c.opts.ReceiversAllowedSources,
-		ReceiversAllowAllSources: c.opts.ReceiversAllowAllSources,
-		APIServer:                apiServer,
+		Log:                     c.log,
+		UID:                     c.opts.UID,
+		Location:                c.opts.Location,
+		OutDir:                  c.opts.OutDir,
+		CheckNodeURI:            c.opts.CheckNodeURI,
+		ClickhouseDSN:           c.opts.ClickhouseDSN,
+		HTTPReceivers:           c.opts.Receivers,
+		ReceiversAllowedSources: c.opts.ReceiversAllowedSources,
+		APIServer:               apiServer,
 	})
 
 	// Start the transaction processor, which kicks off background goroutines

--- a/collector/tx_processor.go
+++ b/collector/tx_processor.go
@@ -166,6 +166,9 @@ func (p *TxProcessor) Start() {
 func (p *TxProcessor) startTransactionReceiverLoop() {
 	p.log.Info("Waiting for transactions...")
 	for txIn := range p.txC {
+		if txIn.Tx == nil {
+			continue
+		}
 		p.processTx(txIn)
 	}
 }

--- a/collector/tx_processor.go
+++ b/collector/tx_processor.go
@@ -173,7 +173,8 @@ func (p *TxProcessor) startTransactionReceiverLoop() {
 }
 
 func (p *TxProcessor) sendTxToReceivers(txIn common.TxIn) {
-	if !p.receiversAllowAllSources && !slices.Contains(p.receiversAllowedSources, txIn.Source) {
+	txAllowed := p.receiversAllowAllSources || slices.Contains(p.receiversAllowedSources, txIn.Source)
+	if !txAllowed {
 		return
 	}
 

--- a/collector/tx_processor.go
+++ b/collector/tx_processor.go
@@ -34,16 +34,15 @@ var (
 )
 
 type TxProcessorOpts struct {
-	Log                      *zap.SugaredLogger
-	OutDir                   string // if empty no files will be written
-	UID                      string
-	Location                 string // location of the collector, will be stored in sourcelogs
-	CheckNodeURI             string
-	ClickhouseDSN            string
-	HTTPReceivers            []string
-	ReceiversAllowedSources  []string
-	ReceiversAllowAllSources bool // if true, allows all sources for receivers
-	APIServer                *api.Server
+	Log                     *zap.SugaredLogger
+	OutDir                  string // if empty no files will be written
+	UID                     string
+	Location                string // location of the collector, will be stored in sourcelogs
+	CheckNodeURI            string
+	ClickhouseDSN           string
+	HTTPReceivers           []string
+	ReceiversAllowedSources []string
+	APIServer               *api.Server
 }
 
 type TxProcessor struct {
@@ -69,7 +68,7 @@ type TxProcessor struct {
 
 	receivers                []TxReceiver
 	receiversAllowedSources  []string
-	receiversAllowAllSources bool // if true, all sources are allowed to send transactions to the receivers
+	receiversAllowAllSources bool
 
 	lastHealthCheckCall time.Time
 
@@ -113,7 +112,7 @@ func NewTxProcessor(opts TxProcessorOpts) *TxProcessor {
 
 		receivers:                receivers,
 		receiversAllowedSources:  opts.ReceiversAllowedSources,
-		receiversAllowAllSources: opts.ReceiversAllowAllSources,
+		receiversAllowAllSources: len(opts.ReceiversAllowedSources) == 1 && opts.ReceiversAllowedSources[0] == "all",
 	}
 }
 


### PR DESCRIPTION
## 📝 Summary

- Making the code a little better structured and easier to understand and extend
- Moved sending to tx receivers to after the sanity checks, which avoids sending duplicates and trash. The checks mostly need less than 100us (0.1ms), and at most up to 0.3ms (not a noticable delay).
- Save transactions to Clickhouse after the inclusion check (instead of before), to avoid storing already included transactions

