### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/cmd/website/main.go
+++ b/cmd/website/main.go
@@ -230,8 +230,8 @@ func getFoldersFromS3(dir string) ([]string, error) {
 	}
 
 	// Print the output
-	lines := strings.Split(string(stdout), "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(string(stdout), "\n")
+	for line := range lines {
 		if line != "" && strings.HasPrefix(line, "20") {
 			folders = append(folders, strings.TrimSuffix(line, "/"))
 		}
@@ -250,8 +250,8 @@ func getFilesFromS3(month string) ([]website.FileEntry, error) {
 	}
 
 	space := regexp.MustCompile(`\s+`)
-	lines := strings.Split(string(stdout), "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(string(stdout), "\n")
+	for line := range lines {
 		if line != "" {
 			line = space.ReplaceAllString(line, " ")
 			parts := strings.Split(line, " ")

--- a/common/utils.go
+++ b/common/utils.go
@@ -125,8 +125,8 @@ func SourceAliasesFromEnv() map[string]string {
 	aliases := make(map[string]string)
 	aliasesRaw := os.Getenv("SRC_ALIASES") // format: alias=url,alias=url
 	if aliasesRaw != "" {
-		entries := strings.Split(aliasesRaw, ",")
-		for _, entry := range entries {
+		entries := strings.SplitSeq(aliasesRaw, ",")
+		for entry := range entries {
 			parts := strings.Split(entry, "=")
 			if len(parts) != 2 {
 				continue


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->

strings.SplitSeq (introduced in Go 1.23)  returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.



## ⛱ Motivation and Context

It significantly reduces memory allocations and can improve performance for long strings.





<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

More info: https://github.com/golang/go/issues/61901


---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
